### PR TITLE
fix error spam and add hotkey

### DIFF
--- a/Defs/Misc/MainButtonDefs/MainButtons.xml
+++ b/Defs/Misc/MainButtonDefs/MainButtons.xml
@@ -6,5 +6,6 @@
         <description>View Colonist Weapons and assign Loadouts</description>
         <tabWindowClass>WeaponsTabReborn.MainTabWindow_Weapons</tabWindowClass>
         <order>35</order>
+        <defaultHotKey></defaultHotKey>
     </MainButtonDef>
 </Defs>

--- a/Defs/Misc/MainButtonDefs/MainButtons.xml
+++ b/Defs/Misc/MainButtonDefs/MainButtons.xml
@@ -6,6 +6,6 @@
         <description>View Colonist Weapons and assign Loadouts</description>
         <tabWindowClass>WeaponsTabReborn.MainTabWindow_Weapons</tabWindowClass>
         <order>35</order>
-        <defaultHotKey></defaultHotKey>
+        <defaultHotKey>L</defaultHotKey>
     </MainButtonDef>
 </Defs>

--- a/Source/WeaponsTabReborn/WeaponsTabReborn/Loadout.cs
+++ b/Source/WeaponsTabReborn/WeaponsTabReborn/Loadout.cs
@@ -16,7 +16,6 @@ namespace WeaponsTabReborn
         public int uniqueID;
         public string label;
         public ThingFilter filter = new ThingFilter();
-        public List<ThingFilter> filters = new List<ThingFilter>();
 
         public static readonly Regex ValidNameRegex = new Regex("^[\\p{L}0-9 '\\-]*$");
 
@@ -36,7 +35,6 @@ namespace WeaponsTabReborn
             Scribe_Values.Look(ref uniqueID, "uniqueID", 0);
             Scribe_Values.Look(ref label, "label");
             Scribe_Deep.Look(ref filter, "filter");
-            Scribe_Deep.Look(ref filters, "filters");
         }
 
         public string GetUniqueLoadID()


### PR DESCRIPTION
Hello, been using this mod for a while now and find it pretty valuable.  I made a couple changes to my own local version that I thought might be beneficial to share.  First, there is an error that occurs every time the game is saved:

`Error: "Cannot use LookDeep to save non-IExposable non-null filters of type System.Collections.Generic.List 1[Verse.ThingFilter]`

I'm not super familiar with the internal design of either Unity or Rimworld,  and it doesn't seem like the error is causing much harm, other than perhaps a very small lag spike, still if it can be resolved without too much bother, may as well, right? After a small amount of trial and error, I found that removing the LookDeep call it was trying to do with the ThingFilter list resolved the error spam, and as far as I can tell, that line wasn't actually doing anything.  I honestly have no idea what the original intent was with having both the ThingFIlter and the ThingFilter list, but after several months of using this now with that change, whatever the original purpose, it doesn't appear to be relevant anymore.  I was mostly waiting to do this PR to see if anything unexpected broke as a result, but at this point I feel reasonably confident that it's safe to push through.  

Beyond that, I also implemented a hotkey, which it seems at least one other person interested in having based on the feature request https://github.com/papercrane1001/-1001-WeaponsTabReborn/issues/1#issue-1666394323.  It actually only requires a single simple line of code to implement, so there's no drawbacks to adding that in as well.  