### PR TITLE
Added static functions to allow integration with BetterPawnControl mod

### DIFF
--- a/Source/WeaponsTabReborn/WeaponsTabReborn/LoadoutDictionary.cs
+++ b/Source/WeaponsTabReborn/WeaponsTabReborn/LoadoutDictionary.cs
@@ -53,5 +53,39 @@ namespace WeaponsTabReborn
 
             return LoadoutRefsByPawn.TryGetValue(pawn);
         }
+
+        //BPC INTEGRATION
+        public static void BPC_SetLoadoutId(Pawn pawn, int loadoutID)
+        {
+            var loadout = CurrentLoadoutDatabase.AllLoadouts.Find(x => x.uniqueID == loadoutID);
+            GetLoadoutTracker(pawn).CurrentLoadout = loadout;
+        }
+
+        public static int BPC_GetLoadoutId(Pawn pawn)
+        {
+            return GetLoadoutTracker(pawn).CurrentLoadout.uniqueID;
+        }
+
+        public static string BPC_GetLoadoutNamebyId(int loudoutId)
+        {
+            return CurrentLoadoutDatabase.AllLoadouts.First(x => x.uniqueID == loudoutId).label;
+        }
+
+        static Dictionary<string, int> BPC_CurrentLoadoutDatabase;
+        public static Dictionary<string, int> BPC_GetWeaponsLoadoutsDatabase()
+        {
+            BPC_CurrentLoadoutDatabase = BPC_CurrentLoadoutDatabase ?? new Dictionary<string, int>();
+
+            foreach (var entry in CurrentLoadoutDatabase.AllLoadouts)
+            {
+                BPC_CurrentLoadoutDatabase.AddDistinct(entry.label, entry.uniqueID);
+            }
+            return BPC_CurrentLoadoutDatabase;
+        }
+
+        public static int BPC_GetDefaultLoadoutId()
+        {
+            return CurrentLoadoutDatabase.DefaultLoadout().uniqueID;
+        }
     }
 }


### PR DESCRIPTION
Hi PapperCrane1001.  In case you don't know, the Rimworld BetterPawnControl mod allows to bulk change policies in all vanilla tabs (and others too). This WeaponsTab mod, well, adds a much needed WeaponsTab to allow a better management of weapons loadout. 

This is PERFECT for BetterPawnControl (BPC).  This Pull Request will allow BPC to integrate with your mod to bulk change the pawn loadouts. 

See below how it will work with BPC:
![WeaponsTabReborn_and_BPC-Integration](https://github.com/papercrane1001/-1001-WeaponsTabReborn/assets/5374128/033a2d05-f9f3-4972-abe2-0d5d19b71f96)

BPC adds two buttons:
1/ to allow the user to change policies
2/ to allow the user manage the settings 

Please let me know if you can approve this merge request and if you have remarks or concerns.  